### PR TITLE
Fix compiling with newest autoconf.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,9 +3,11 @@
 
 AC_PREREQ([2.68])
 AC_INIT([rnn], [1.0], [jnamika@gmail.com])
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_CONFIG_SRCDIR([src/common/rnn.c])
 AC_CONFIG_HEADERS([config.h])
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+LT_INIT
 AC_CONFIG_MACRO_DIR([m4])
 
 # Checks for programs.


### PR DESCRIPTION
autoconf version: 2.69

Current master:
```
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
configure.ac:12: installing './compile'
automake: warnings are treated as errors
src/python/Makefile.am:2: warning: source file '../common/rnn.c' is in a subdirectory,
src/python/Makefile.am:2: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
src/python/Makefile.am:2: warning: source file '../common/rnn_runner.c' is in a subdirectory,
src/python/Makefile.am:2: but option 'subdir-objects' is disabled
src/python/Makefile.am:2: warning: source file '../common/utils.c' is in a subdirectory,
src/python/Makefile.am:2: but option 'subdir-objects' is disabled
/usr/share/automake-1.15/am/ltlibrary.am: warning: 'librnnrunner.la': linking libtool libraries using a non-POSIX
/usr/share/automake-1.15/am/ltlibrary.am: archiver requires 'AM_PROG_AR' in 'configure.ac'
src/python/Makefile.am:1:   while processing Libtool library 'librnnrunner.la'
src/rnn-generate/Makefile.am:2: warning: source file '../common/rnn.c' is in a subdirectory,
src/rnn-generate/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-generate/Makefile.am:2: warning: source file '../common/rnn_runner.c' is in a subdirectory,
src/rnn-generate/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-generate/Makefile.am:2: warning: source file '../common/utils.c' is in a subdirectory,
src/rnn-generate/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-learn/Makefile.am:2: warning: source file '../common/rnn.c' is in a subdirectory,
src/rnn-learn/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-learn/Makefile.am:2: warning: source file '../common/rnn_lyapunov.c' is in a subdirectory,
src/rnn-learn/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-learn/Makefile.am:2: warning: source file '../common/entropy.c' is in a subdirectory,
src/rnn-learn/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-learn/Makefile.am:2: warning: source file '../common/solver.c' is in a subdirectory,
src/rnn-learn/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-learn/Makefile.am:2: warning: source file '../common/utils.c' is in a subdirectory,
src/rnn-learn/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-lyapunov/Makefile.am:2: warning: source file '../common/rnn.c' is in a subdirectory,
src/rnn-lyapunov/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-lyapunov/Makefile.am:2: warning: source file '../common/rnn_runner.c' is in a subdirectory,
src/rnn-lyapunov/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-lyapunov/Makefile.am:2: warning: source file '../common/rnn_lyapunov.c' is in a subdirectory,
src/rnn-lyapunov/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-lyapunov/Makefile.am:2: warning: source file '../common/solver.c' is in a subdirectory,
src/rnn-lyapunov/Makefile.am:2: but option 'subdir-objects' is disabled
src/rnn-lyapunov/Makefile.am:2: warning: source file '../common/utils.c' is in a subdirectory,
src/rnn-lyapunov/Makefile.am:2: but option 'subdir-objects' is disabled
src/unit-test/Makefile.am:2: warning: source file '../common/rnn.c' is in a subdirectory,
src/unit-test/Makefile.am:2: but option 'subdir-objects' is disabled
src/unit-test/Makefile.am:2: warning: source file '../common/solver.c' is in a subdirectory,
src/unit-test/Makefile.am:2: but option 'subdir-objects' is disabled
src/unit-test/Makefile.am:2: warning: source file '../common/entropy.c' is in a subdirectory,
src/unit-test/Makefile.am:2: but option 'subdir-objects' is disabled
src/unit-test/Makefile.am:2: warning: source file '../common/rnn_lyapunov.c' is in a subdirectory,
src/unit-test/Makefile.am:2: but option 'subdir-objects' is disabled
src/unit-test/Makefile.am:2: warning: source file '../common/rnn_runner.c' is in a subdirectory,
src/unit-test/Makefile.am:2: but option 'subdir-objects' is disabled
src/unit-test/Makefile.am:2: warning: source file '../common/utils.c' is in a subdirectory,
src/unit-test/Makefile.am:2: but option 'subdir-objects' is disabled
src/unit-test/Makefile.am:2: warning: source file '../rnn-learn/target.c' is in a subdirectory,
src/unit-test/Makefile.am:2: but option 'subdir-objects' is disabled
src/unit-test/Makefile.am:2: warning: source file '../rnn-learn/parse.c' is in a subdirectory,
src/unit-test/Makefile.am:2: but option 'subdir-objects' is disabled
parallel-tests: installing './test-driver'
autoreconf: automake failed with exit status: 1
```

After adding the `subdir-objects` to `AM_INIT_AUTOMAKE`:
```
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
configure.ac:12: installing './compile'
automake: warnings are treated as errors
/usr/share/automake-1.15/am/ltlibrary.am: warning: 'librnnrunner.la': linking libtool libraries using a non-POSIX
/usr/share/automake-1.15/am/ltlibrary.am: archiver requires 'AM_PROG_AR' in 'configure.ac'
src/python/Makefile.am:1:   while processing Libtool library 'librnnrunner.la'
parallel-tests: installing './test-driver'
autoreconf: automake failed with exit status: 1```